### PR TITLE
Evolution of Exception Handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
@@ -1,6 +1,7 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
+import dev.drugowick.algaworks.algafoodapi.api.exceptionhandler.ApiError;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.City;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -86,5 +88,25 @@ public class CityController {
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         cityCrudService.delete(id);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<?> handler(EntityNotFoundException exception) {
+        ApiError apiError = ApiError.builder()
+                .dateTime(LocalDateTime.now())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(apiError);
+    }
+
+    @ExceptionHandler(GenericBusinessException.class)
+    public ResponseEntity<?> handler(GenericBusinessException exception) {
+        ApiError apiError = ApiError.builder()
+                .dateTime(LocalDateTime.now())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
@@ -55,7 +55,7 @@ public class CityController {
             return ResponseEntity.status(HttpStatus.CREATED)
                     .body(city);
         } catch (EntityNotFoundException e) {
-            throw new GenericBusinessException(e.getMessage());
+            throw new GenericBusinessException(e.getMessage(), e);
         }
     }
 
@@ -70,7 +70,7 @@ public class CityController {
             cityToUpdate = cityCrudService.save(cityToUpdate);
             return ResponseEntity.ok(cityToUpdate);
         } catch (EntityNotFoundException e) {
-            throw new GenericBusinessException(e.getMessage());
+            throw new GenericBusinessException(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
@@ -2,6 +2,7 @@ package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.City;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.CityRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.CityCrudService;
@@ -45,8 +46,7 @@ public class CityController {
     public ResponseEntity<?> save(@RequestBody City city) {
         // Temporary. Client should not send an ID when posting. See #2.
         if (city.getId() != null || city.getProvince() == null) {
-            return ResponseEntity.badRequest()
-                    .body("Invalid request body.");
+            throw new GenericBusinessException("You should not send an ID when saving or updating an entity.");
         }
 
         try {
@@ -55,7 +55,7 @@ public class CityController {
             return ResponseEntity.status(HttpStatus.CREATED)
                     .body(city);
         } catch (EntityNotFoundException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            throw new GenericBusinessException(e.getMessage());
         }
     }
 
@@ -70,7 +70,7 @@ public class CityController {
             cityToUpdate = cityCrudService.save(cityToUpdate);
             return ResponseEntity.ok(cityToUpdate);
         } catch (EntityNotFoundException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            throw new GenericBusinessException(e.getMessage());
         }
     }
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
@@ -1,7 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.City;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.CityRepository;
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("cities")
@@ -39,14 +37,8 @@ public class CityController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<City> get(@PathVariable Long id) {
-        Optional<City> city = cityRepository.findById(id);
-
-        if (city.isPresent()) {
-            return ResponseEntity.ok(city.get());
-        }
-
-        return ResponseEntity.notFound().build();
+    public City get(@PathVariable Long id) {
+        return cityCrudService.findOrElseThrow(id);
     }
 
     @PostMapping
@@ -69,47 +61,30 @@ public class CityController {
 
     @PutMapping("/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody City city) {
-        Optional<City> cityToUpdate = cityRepository.findById(id);
+        City cityToUpdate = cityCrudService.findOrElseThrow(id);
 
-        /**
-         * Not found because the URI is not a valid resource on the application.
-         */
-        if (cityToUpdate.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
+        BeanUtils.copyProperties(city, cityToUpdate, "id");
 
         try {
-            BeanUtils.copyProperties(city, cityToUpdate.get(), "id");
             // The save method will update when an existing ID is being passed.
-            City cityUpdated = cityCrudService.save(cityToUpdate.get());
-            return ResponseEntity.ok(cityUpdated);
+            cityToUpdate = cityCrudService.save(cityToUpdate);
+            return ResponseEntity.ok(cityToUpdate);
         } catch (EntityNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 
     @PatchMapping("/{id}")
     public ResponseEntity<?> partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> cityMap) {
-        Optional<City> cityToUpdate = cityRepository.findById(id);
+        City cityToUpdate = cityCrudService.findOrElseThrow(id);
 
-        if (cityToUpdate.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
+        ObjectMerger.mergeRequestBodyToGenericObject(cityMap, cityToUpdate, City.class);
 
-        ObjectMerger.mergeRequestBodyToGenericObject(cityMap, cityToUpdate.get(), City.class);
-
-        return update(id, cityToUpdate.get());
+        return update(id, cityToUpdate);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> delete(@PathVariable Long id) {
-        try {
-            cityCrudService.delete(id);
-            return ResponseEntity.noContent().build();
-        } catch (EntityBeingUsedException exception) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(exception.getMessage());
-        } catch (EntityNotFoundException exception) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
-        }
+    public void delete(@PathVariable Long id) {
+        cityCrudService.delete(id);
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CityController.java
@@ -1,7 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
-import dev.drugowick.algaworks.algafoodapi.api.exceptionhandler.ApiError;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.City;
@@ -12,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -90,23 +88,4 @@ public class CityController {
         cityCrudService.delete(id);
     }
 
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<?> handler(EntityNotFoundException exception) {
-        ApiError apiError = ApiError.builder()
-                .dateTime(LocalDateTime.now())
-                .message(exception.getMessage())
-                .build();
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(apiError);
-    }
-
-    @ExceptionHandler(GenericBusinessException.class)
-    public ResponseEntity<?> handler(GenericBusinessException exception) {
-        ApiError apiError = ApiError.builder()
-                .dateTime(LocalDateTime.now())
-                .message(exception.getMessage())
-                .build();
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
-    }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CuisineController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CuisineController.java
@@ -1,6 +1,7 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Cuisine;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.CuisineRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.CuisineCrudService;
@@ -39,8 +40,7 @@ public class CuisineController {
 	public ResponseEntity<Cuisine> save(@RequestBody Cuisine cuisine) {
 		// Temporary. Client should not send an ID when posting. See #2.
 		if (cuisine.getId() != null) {
-			return ResponseEntity.badRequest()
-					.build();
+			throw new GenericBusinessException("You should not send an ID when saving or updating an entity.");
 		}
 		return ResponseEntity.status(HttpStatus.CREATED).body(cuisinesCrudService.save(cuisine));
 	}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CuisineController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/CuisineController.java
@@ -1,8 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Cuisine;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.CuisineRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.CuisineCrudService;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping(value = "/cuisines")
@@ -45,62 +42,40 @@ public class CuisineController {
 			return ResponseEntity.badRequest()
 					.build();
 		}
-		return ResponseEntity.status(HttpStatus.CREATED).body(cuisinesCrudService.create(cuisine));
+		return ResponseEntity.status(HttpStatus.CREATED).body(cuisinesCrudService.save(cuisine));
 	}
-	
-	@GetMapping(value = { "/{id}" })
-	public ResponseEntity<Cuisine> get(@PathVariable Long id) {
-		Optional<Cuisine> cuisine = cuisineRepository.findById(id);
 
-		if (cuisine.isPresent()) {
-			return ResponseEntity.ok(cuisine.get());
-		}
-
-		return ResponseEntity.notFound().build();
+	@GetMapping(value = {"/{id}"})
+	public Cuisine get(@PathVariable Long id) {
+		return cuisinesCrudService.findOrElseThrow(id);
 	}
-	
+
 	@PutMapping(value = "/{id}")
-	public ResponseEntity<Cuisine> update(@PathVariable Long id, @RequestBody Cuisine cuisine) {
-		Optional<Cuisine> cuisineToUpdate = cuisineRepository.findById(id);
+	public Cuisine update(@PathVariable Long id, @RequestBody Cuisine cuisine) {
+		Cuisine cuisineToUpdate = cuisinesCrudService.findOrElseThrow(id);
 
-		if (cuisineToUpdate.isPresent()) {
-			BeanUtils.copyProperties(cuisine, cuisineToUpdate.get(), "id");
-			Cuisine cuisineUpdated = cuisinesCrudService.update(id, cuisineToUpdate.get());
-			return ResponseEntity.ok(cuisineUpdated);
-		}
-
-		return ResponseEntity.notFound().build();
+		BeanUtils.copyProperties(cuisine, cuisineToUpdate, "id");
+		// The save method will update when an existing ID is being passed.
+		return cuisinesCrudService.save(cuisineToUpdate);
 	}
 
 	@PatchMapping("/{id}")
-	public ResponseEntity<?> partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> cuisineMap) {
-		Optional<Cuisine> cuisineToUpdate = cuisineRepository.findById(id);
+	public Cuisine partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> cuisineMap) {
+		Cuisine cuisineToUpdate = cuisinesCrudService.findOrElseThrow(id);
 
-		if (cuisineToUpdate.isEmpty()) {
-			return ResponseEntity.notFound().build();
-		}
+		ObjectMerger.mergeRequestBodyToGenericObject(cuisineMap, cuisineToUpdate, Cuisine.class);
 
-		ObjectMerger.mergeRequestBodyToGenericObject(cuisineMap, cuisineToUpdate.get(), Cuisine.class);
-
-		return update(id, cuisineToUpdate.get());
+		return update(id, cuisineToUpdate);
 	}
 
 	@DeleteMapping(value = "/{id}")
-	public ResponseEntity<?> delete(@PathVariable Long id) {
-		try {
-			cuisinesCrudService.delete(id);
-			return ResponseEntity.noContent().build();
-		} catch (EntityBeingUsedException e) {
-			return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
-		} catch (EntityNotFoundException e) {
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-		}
-
+	public void delete(@PathVariable Long id) {
+		cuisinesCrudService.delete(id);
 	}
-/**
+
 	@GetMapping(value = "/by-name")
 	public List<Cuisine> cuisinesByName(@RequestParam("name") String name) {
-		return cuisineRepository.listByName(name);
+		return cuisineRepository.byNameLike(name);
 	}
- */
+
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/PaymentMethodController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/PaymentMethodController.java
@@ -1,6 +1,7 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.PaymentMethod;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.PaymentMethodRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.PaymentMethodCrudService;
@@ -39,8 +40,7 @@ public class PaymentMethodController {
     public ResponseEntity<PaymentMethod> save(@RequestBody PaymentMethod paymentMethod) {
         // Temporary. Client should not send an ID when posting. See #2.
         if (paymentMethod.getId() != null) {
-            return ResponseEntity.badRequest()
-                    .build();
+            throw new GenericBusinessException("You should not send an ID when saving or updating an entity.");
         }
         return ResponseEntity.status(HttpStatus.CREATED).body(paymentMethodCrudService.save(paymentMethod));
     }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/PermissionController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/PermissionController.java
@@ -1,6 +1,7 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Permission;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.PermissionRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.PermissionCrudService;
@@ -39,8 +40,7 @@ public class PermissionController {
     public ResponseEntity<Permission> save(@RequestBody Permission permission) {
         // Temporary. Client should not send an ID when posting. See #2.
         if (permission.getId() != null) {
-            return ResponseEntity.badRequest()
-                    .build();
+            throw new GenericBusinessException("You should not send an ID when saving or updating an entity.");
         }
         return ResponseEntity.status(HttpStatus.CREATED).body(permissionCrudService.save(permission));
     }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/ProvinceController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/ProvinceController.java
@@ -1,6 +1,7 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Province;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.ProvinceRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.ProvinceCrudService;
@@ -44,9 +45,8 @@ public class ProvinceController {
 	public ResponseEntity<Province> save(@RequestBody Province province) {
 		// Temporary. Client should not send an ID when posting. See #2.
 		if (province.getId() != null) {
-			return ResponseEntity.badRequest()
-					.build();
-		}
+            throw new GenericBusinessException("You should not send an ID when saving or updating an entity.");
+        }
 
 		province = provinceCrudService.save(province);
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/ProvinceController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/ProvinceController.java
@@ -1,8 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Province;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.ProvinceRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.ProvinceCrudService;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping(value = "/provinces")
@@ -39,14 +36,8 @@ public class ProvinceController {
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<Province> get(@PathVariable Long id) {
-		Optional<Province> province = provinceRepository.findById(id);
-
-		if (province.isPresent()) {
-			return ResponseEntity.ok(province.get());
-		}
-
-		return ResponseEntity.notFound().build();
+	public Province get(@PathVariable Long id) {
+		return provinceCrudService.findOrElseThrow(id);
 	}
 
 	@PostMapping
@@ -61,47 +52,29 @@ public class ProvinceController {
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(province);
 	}
-	
+
 	@PutMapping(value = "/{id}")
-	public ResponseEntity<Province> update(@PathVariable Long id, @RequestBody Province province) {
-		Optional<Province> provinceToUpdate = provinceRepository.findById(id);
+	public Province update(@PathVariable Long id, @RequestBody Province province) {
+		Province provinceToUpdate = provinceCrudService.findOrElseThrow(id);
 
-		/**
-		 * Not found because the URI is not a valid resource on the application.
-		 */
-		if (provinceToUpdate.isEmpty()) {
-			return ResponseEntity.notFound().build();
-		}
+		BeanUtils.copyProperties(province, provinceToUpdate, "id");
 
-		BeanUtils.copyProperties(province, provinceToUpdate.get(), "id");
 		// The save method will update when an existing ID is being passed.
-		Province provinceUpdated = provinceRepository.save(provinceToUpdate.get());
-		return ResponseEntity.ok(provinceUpdated);
+		return provinceRepository.save(provinceToUpdate);
 	}
 
 	@PatchMapping("/{id}")
-	public ResponseEntity<?> partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> provinceMap) {
-		Optional<Province> provinceToUpdate = provinceRepository.findById(id);
+	public Province partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> provinceMap) {
+		Province provinceToUpdate = provinceCrudService.findOrElseThrow(id);
 
-		if (provinceToUpdate.isEmpty()) {
-			return ResponseEntity.notFound().build();
-		}
+		ObjectMerger.mergeRequestBodyToGenericObject(provinceMap, provinceToUpdate, Province.class);
 
-		ObjectMerger.mergeRequestBodyToGenericObject(provinceMap, provinceToUpdate.get(), Province.class);
-
-		return update(id, provinceToUpdate.get());
+		return update(id, provinceToUpdate);
 	}
 
 	@DeleteMapping(value = "/{id}")
-	public ResponseEntity<?> delete(@PathVariable Long id) {
-		try {
-			provinceCrudService.delete(id);
-			return ResponseEntity.noContent().build();
-		} catch (EntityBeingUsedException exception) {
-			return ResponseEntity.status(HttpStatus.CONFLICT).body(exception.getMessage());
-		} catch (EntityNotFoundException exception) {
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
-		}
+	public void delete(@PathVariable Long id) {
+		provinceCrudService.delete(id);
 	}
 	
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
@@ -2,6 +2,7 @@ package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Restaurant;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.RestaurantRepository;
 import dev.drugowick.algaworks.algafoodapi.domain.service.RestaurantCrudService;
@@ -34,8 +35,7 @@ public class RestaurantController {
 	public ResponseEntity<?> save(@RequestBody Restaurant restaurant) {
 		// Temporary. Client should not send an ID when posting. See #2.
 		if (restaurant.getId() != null) {
-			return ResponseEntity.badRequest()
-					.body("Invalid request body.");
+			throw new GenericBusinessException("You should not send an ID when saving or updating an entity.");
 		}
 
 		try {
@@ -44,7 +44,7 @@ public class RestaurantController {
 			return ResponseEntity.status(HttpStatus.CREATED)
 					.body(restaurant);
 		} catch (EntityNotFoundException e) {
-			return ResponseEntity.badRequest().body(e.getMessage());
+			throw new GenericBusinessException(e.getMessage());
 		}
 	}
 
@@ -54,17 +54,22 @@ public class RestaurantController {
 	}
 
 	@PutMapping("/{id}")
-	public Restaurant update(@PathVariable Long id, @RequestBody Restaurant restaurant) {
+	public ResponseEntity<?> update(@PathVariable Long id, @RequestBody Restaurant restaurant) {
 		Restaurant restaurantToUpdate = restaurantCrudService.findOrElseThrow(id);
 
 		BeanUtils.copyProperties(restaurant, restaurantToUpdate,
 				"id", "paymentMethods", "address", "createdDate", "updatedDate");
-		// The save method will update when an existing ID is being passed.
-		return restaurantCrudService.save(restaurantToUpdate);
+		try {
+			// The save method will update when an existing ID is being passed.
+			restaurantCrudService.save(restaurantToUpdate);
+			return ResponseEntity.ok(restaurantToUpdate);
+		} catch (EntityNotFoundException e) {
+			throw new GenericBusinessException(e.getMessage());
+		}
 	}
 
 	@PatchMapping("/{id}")
-	public Restaurant partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> restaurantMap) {
+	public ResponseEntity<?> partialUpdate(@PathVariable Long id, @RequestBody Map<String, Object> restaurantMap) {
 		Restaurant restaurantToUpdate = restaurantCrudService.findOrElseThrow(id);
 
 		ObjectMerger.mergeRequestBodyToGenericObject(restaurantMap, restaurantToUpdate, Restaurant.class);

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
@@ -1,7 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Restaurant;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.RestaurantRepository;
@@ -95,16 +94,8 @@ public class RestaurantController {
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<?> delete(@PathVariable Long id) {
-		try {
-			restaurantCrudService.delete(id);
-			return ResponseEntity.noContent().build();
-
-		} catch (EntityBeingUsedException exception) {
-			return ResponseEntity.status(HttpStatus.CONFLICT).body(exception.getMessage());
-		} catch (EntityNotFoundException exception) {
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
-		}
+	public void delete(@PathVariable Long id) {
+		restaurantCrudService.delete(id);
 	}
 
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
@@ -44,7 +44,7 @@ public class RestaurantController {
 			return ResponseEntity.status(HttpStatus.CREATED)
 					.body(restaurant);
 		} catch (EntityNotFoundException e) {
-			throw new GenericBusinessException(e.getMessage());
+			throw new GenericBusinessException(e.getMessage(), e);
 		}
 	}
 
@@ -64,7 +64,7 @@ public class RestaurantController {
 			restaurantCrudService.save(restaurantToUpdate);
 			return ResponseEntity.ok(restaurantToUpdate);
 		} catch (EntityNotFoundException e) {
-			throw new GenericBusinessException(e.getMessage());
+			throw new GenericBusinessException(e.getMessage(), e);
 		}
 	}
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
@@ -1,7 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
-import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Restaurant;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.RestaurantRepository;
@@ -10,7 +9,6 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
@@ -97,14 +95,7 @@ public class RestaurantController {
 
 	@DeleteMapping("/{id}")
 	public void delete(@PathVariable Long id) {
-		try {
-			restaurantCrudService.delete(id);
-		} catch (EntityBeingUsedException exception) {
-			throw new ResponseStatusException(HttpStatus.CONFLICT, exception.getMessage());
-		} catch (EntityNotFoundException exception) {
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, exception.getMessage());
-		}
-
+		restaurantCrudService.delete(id);
 	}
 
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/RestaurantController.java
@@ -1,6 +1,7 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller;
 
 import dev.drugowick.algaworks.algafoodapi.api.controller.utils.ObjectMerger;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Restaurant;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.RestaurantRepository;
@@ -9,6 +10,7 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
@@ -95,7 +97,14 @@ public class RestaurantController {
 
 	@DeleteMapping("/{id}")
 	public void delete(@PathVariable Long id) {
-		restaurantCrudService.delete(id);
+		try {
+			restaurantCrudService.delete(id);
+		} catch (EntityBeingUsedException exception) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, exception.getMessage());
+		} catch (EntityNotFoundException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, exception.getMessage());
+		}
+
 	}
 
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/utils/ObjectMerger.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/controller/utils/ObjectMerger.java
@@ -1,5 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.api.controller.utils;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.util.ReflectionUtils;
 
@@ -24,6 +25,8 @@ public class ObjectMerger {
      */
     public static void mergeRequestBodyToGenericObject(Map<String, Object> objectMap, Object objectToUpdate, Class type) {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true);
         Object newObject = objectMapper.convertValue(objectMap, type);
 
         objectMap.forEach((fieldProp, valueProp) -> {

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ApiError {
 
-    private LocalDateTime dateTime;
+    private LocalDateTime timestamp;
     private String message;
+
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
@@ -1,0 +1,14 @@
+package dev.drugowick.algaworks.algafoodapi.api.exceptionhandler;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ApiError {
+
+    private LocalDateTime dateTime;
+    private String message;
+}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
@@ -16,6 +16,7 @@ public class ApiError {
     private String title;
     private String detail;
 
+    private String userMessage;
     private LocalDateTime timestamp;
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiError.java
@@ -1,15 +1,21 @@
 package dev.drugowick.algaworks.algafoodapi.api.exceptionhandler;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Builder
 public class ApiError {
 
+    private Integer status;
+    private String type;
+    private String title;
+    private String detail;
+
     private LocalDateTime timestamp;
-    private String message;
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 public enum ApiErrorType {
 
+    INTERNAL_SERVER_ERROR("/internal-server-error", "Internal Server Error"),
     INVALID_PARAMETER("/invalid-parameter", "Invalid Parameter"),
     MESSAGE_NOT_READABLE("/message-not-readable", "Message Not Readable"),
     RESOURCE_NOT_FOUND("/resource-not-found", "Resource Not Found"),

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
@@ -1,0 +1,25 @@
+package dev.drugowick.algaworks.algafoodapi.api.exceptionhandler;
+
+import lombok.Getter;
+
+/**
+ * This ENUM helps to determine the title and type properties when returning an {@link ApiError}.
+ * Those values are predetermined here for the ENUM values.
+ * <p>
+ * This class also defines the URI prefix for the type property of {@link ApiError}.
+ */
+@Getter
+public enum ApiErrorType {
+
+    ENTITY_NOT_FOUND("/entity-not-found", "Entity Not Found"),
+    ENTITY_BEING_USED("/entity-being-used", "Entity Being Used"),
+    BUSINESS_EXCEPTION("/business-exception", "Business Exception");
+
+    private String title;
+    private String uri;
+
+    ApiErrorType(String path, String title) {
+        this.uri = "https://drugo.dev/algafoodapi" + path;
+        this.title = title;
+    }
+}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 public enum ApiErrorType {
 
+    MESSAGE_NOT_READABLE("/message-not-readable", "Message Not Readable"),
     ENTITY_NOT_FOUND("/entity-not-found", "Entity Not Found"),
     ENTITY_BEING_USED("/entity-being-used", "Entity Being Used"),
     BUSINESS_EXCEPTION("/business-exception", "Business Exception");

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiErrorType.java
@@ -11,8 +11,9 @@ import lombok.Getter;
 @Getter
 public enum ApiErrorType {
 
+    INVALID_PARAMETER("/invalid-parameter", "Invalid Parameter"),
     MESSAGE_NOT_READABLE("/message-not-readable", "Message Not Readable"),
-    ENTITY_NOT_FOUND("/entity-not-found", "Entity Not Found"),
+    RESOURCE_NOT_FOUND("/resource-not-found", "Resource Not Found"),
     ENTITY_BEING_USED("/entity-being-used", "Entity Being Used"),
     BUSINESS_EXCEPTION("/business-exception", "Business Exception");
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -25,6 +25,20 @@ import java.util.stream.Collectors;
 @ControllerAdvice
 public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handler(Exception exception, WebRequest request) {
+
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        ApiErrorType apiErrorType = ApiErrorType.INTERNAL_SERVER_ERROR;
+        String detail = exception.getMessage();
+
+        exception.printStackTrace();
+
+        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail).build();
+
+        return handleExceptionInternal(exception, apiError, new HttpHeaders(), status, request);
+    }
+
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<?> handler(EntityNotFoundException exception, WebRequest request) {
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -65,6 +65,32 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers,
+                                                        HttpStatus status, WebRequest request) {
+
+        if (ex instanceof MethodArgumentTypeMismatchException) {
+            return handleMethodArgumentTypeMismatch((MethodArgumentTypeMismatchException) ex, headers, status, request);
+        }
+
+        return super.handleTypeMismatch(ex, headers, status, request);
+    }
+
+    private ResponseEntity<Object> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException ex, HttpHeaders headers,
+            HttpStatus status, WebRequest request) {
+
+        ApiErrorType problemType = ApiErrorType.INVALID_PARAMETER;
+
+        String detail = String.format("The URL param '%s' with value '%s', "
+                        + "is invalid. The value must be compatible with the type %s.",
+                ex.getName(), ex.getValue(), ex.getRequiredType().getSimpleName());
+
+        ApiError apiError = createApiErrorBuilder(status, problemType, detail).build();
+
+        return handleExceptionInternal(ex, apiError, headers, status, request);
+    }
+
+    @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
                                                                   HttpHeaders headers, HttpStatus status, WebRequest request) {
         Throwable rootCause = ExceptionUtils.getRootCause(ex);

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 @ControllerAdvice
 public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
 
+    public static final String DEFAULT_USER_MESSAGE = "Internal error. Please try again or contact the system administrator.";
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handler(Exception exception, WebRequest request) {
 
@@ -34,7 +36,8 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
 
         exception.printStackTrace();
 
-        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail).build();
+        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
+                .build();
 
         return handleExceptionInternal(exception, apiError, new HttpHeaders(), status, request);
     }
@@ -47,6 +50,7 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         String detail = exception.getMessage();
 
         ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
+                .userMessage(detail)
                 .build();
 
         return handleExceptionInternal(exception, apiError, new HttpHeaders(), status, request);
@@ -60,6 +64,7 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         String detail = exception.getMessage();
 
         ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
+                .userMessage(detail)
                 .build();
 
         return handleExceptionInternal(exception, apiError, new HttpHeaders(), status, request);
@@ -73,6 +78,7 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         String detail = exception.getMessage();
 
         ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
+                .userMessage(detail)
                 .build();
 
         return handleExceptionInternal(exception, apiError, new HttpHeaders(), status, request);
@@ -99,7 +105,8 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
                         + "is invalid. The value must be compatible with the type %s.",
                 ex.getName(), ex.getValue(), ex.getRequiredType().getSimpleName());
 
-        ApiError apiError = createApiErrorBuilder(status, problemType, detail).build();
+        ApiError apiError = createApiErrorBuilder(status, problemType, detail)
+                .build();
 
         return handleExceptionInternal(ex, apiError, headers, status, request);
     }
@@ -133,7 +140,8 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         String detail = String.format("The property '%s' does not exist. Remove or fix it and try again",
                 path);
 
-        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail).build();
+        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
+                .build();
 
         return handleExceptionInternal(ex, apiError, headers, status, request);
     }
@@ -147,7 +155,8 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
                         + "is invalid. The value must be compatible with the type %s.",
                 path, ex.getValue(), ex.getTargetType().getSimpleName());
 
-        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail).build();
+        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
+                .build();
 
         return handleExceptionInternal(ex, apiError, headers, status, request);
     }
@@ -171,12 +180,14 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
                     .timestamp(LocalDateTime.now())
                     .title(status.getReasonPhrase())
                     .status(status.value())
+                    .userMessage(DEFAULT_USER_MESSAGE)
                     .build();
         } else if (body instanceof String) {
             body = ApiError.builder()
                     .timestamp(LocalDateTime.now())
                     .title((String) body)
                     .status(status.value())
+                    .userMessage(DEFAULT_USER_MESSAGE)
                     .build();
         }
 
@@ -199,6 +210,7 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
                 .type(apiErrorType.getUri())
                 .title(apiErrorType.getTitle())
                 .detail(detail)
+                .userMessage(DEFAULT_USER_MESSAGE)
                 .timestamp(LocalDateTime.now());
     }
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -70,7 +70,8 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         }
 
         ApiErrorType apiErrorType = ApiErrorType.MESSAGE_NOT_READABLE;
-        String detail = "Invalid request body. Check your syntax.";
+        String detail = "Invalid request body. Check the syntax and properties of your request body" +
+                ".";
 
         ApiError problem = createApiErrorBuilder(status, apiErrorType, detail)
                 .build();

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -2,10 +2,12 @@ package dev.drugowick.algaworks.algafoodapi.api.exceptionhandler;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.PropertyBindingException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +15,11 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @ControllerAdvice
@@ -25,7 +29,7 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<?> handler(EntityNotFoundException exception, WebRequest request) {
 
         HttpStatus status = HttpStatus.NOT_FOUND;
-        ApiErrorType apiErrorType = ApiErrorType.ENTITY_NOT_FOUND;
+        ApiErrorType apiErrorType = ApiErrorType.RESOURCE_NOT_FOUND;
         String detail = exception.getMessage();
 
         ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail)
@@ -67,6 +71,8 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
 
         if (rootCause instanceof InvalidFormatException) {
             return handleInvalidFormatException((InvalidFormatException) rootCause, headers, status, request);
+        } else if (rootCause instanceof PropertyBindingException) {
+            return handlePropertyBindingException((PropertyBindingException) rootCause, headers, status, request);
         }
 
         ApiErrorType apiErrorType = ApiErrorType.MESSAGE_NOT_READABLE;
@@ -79,15 +85,26 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(ex, problem, headers, status, request);
     }
 
+    private ResponseEntity<Object> handlePropertyBindingException(PropertyBindingException ex,
+                                                                  HttpHeaders headers, HttpStatus status, WebRequest request) {
+        String path = joinPath(ex.getPath());
+
+        ApiErrorType apiErrorType = ApiErrorType.MESSAGE_NOT_READABLE;
+        String detail = String.format("The property '%s' does not exist. Remove or fix it and try again",
+                path);
+
+        ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail).build();
+
+        return handleExceptionInternal(ex, apiError, headers, status, request);
+    }
+
     private ResponseEntity<Object> handleInvalidFormatException(InvalidFormatException ex,
                                                                 HttpHeaders headers, HttpStatus status, WebRequest request) {
-        String path = ex.getPath().stream()
-                .map(JsonMappingException.Reference::getFieldName)
-                .collect(Collectors.joining("."));
+        String path = joinPath(ex.getPath());
 
         ApiErrorType apiErrorType = ApiErrorType.MESSAGE_NOT_READABLE;
         String detail = String.format("The property '%s' with value '%s', "
-                        + "in invalid. The value must be compatible with the type %s.",
+                        + "is invalid. The value must be compatible with the type %s.",
                 path, ex.getValue(), ex.getTargetType().getSimpleName());
 
         ApiError apiError = createApiErrorBuilder(status, apiErrorType, detail).build();
@@ -143,5 +160,17 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
                 .title(apiErrorType.getTitle())
                 .detail(detail)
                 .timestamp(LocalDateTime.now());
+    }
+
+    /**
+     * A helper method to join property names with a dot.
+     *
+     * @param references
+     * @return
+     */
+    private String joinPath(List<JsonMappingException.Reference> references) {
+        return references.stream()
+                .map(ref -> ref.getFieldName())
+                .collect(Collectors.joining("."));
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -1,0 +1,62 @@
+package dev.drugowick.algaworks.algafoodapi.api.exceptionhandler;
+
+import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiError> handler(EntityNotFoundException exception) {
+        ApiError apiError = ApiError.builder()
+                .timestamp(LocalDateTime.now())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(apiError);
+    }
+
+    @ExceptionHandler(EntityBeingUsedException.class)
+    public ResponseEntity<ApiError> handler(EntityBeingUsedException exception) {
+        ApiError apiError = ApiError.builder()
+                .timestamp(LocalDateTime.now())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(apiError);
+    }
+
+    @ExceptionHandler(GenericBusinessException.class)
+    public ResponseEntity<ApiError> handler(GenericBusinessException exception) {
+        ApiError apiError = ApiError.builder()
+                .timestamp(LocalDateTime.now())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
+    }
+
+    /**
+     * Example of handling exceptions of Spring (not your own code), in order to provide your custom model for other exceptions.
+     *
+     * @param exception HttpMediaTypeNotSupportedException
+     * @return The ApiError with Unsupported Media Type (415) HTTP status code.
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<?> handler(HttpMediaTypeNotSupportedException exception) {
+        ApiError apiError = ApiError.builder()
+                .timestamp(LocalDateTime.now())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(apiError);
+    }
+}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -3,60 +3,78 @@ package dev.drugowick.algaworks.algafoodapi.api.exceptionhandler;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.GenericBusinessException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.LocalDateTime;
 
 @ControllerAdvice
-public class ApiExceptionHandler {
+public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ApiError> handler(EntityNotFoundException exception) {
-        ApiError apiError = ApiError.builder()
-                .timestamp(LocalDateTime.now())
-                .message(exception.getMessage())
-                .build();
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(apiError);
+    public ResponseEntity<?> handler(EntityNotFoundException exception, WebRequest request) {
+        return handleExceptionInternal(
+                exception,
+                exception.getMessage(),
+                new HttpHeaders(),
+                HttpStatus.NOT_FOUND,
+                request
+        );
     }
 
     @ExceptionHandler(EntityBeingUsedException.class)
-    public ResponseEntity<ApiError> handler(EntityBeingUsedException exception) {
-        ApiError apiError = ApiError.builder()
-                .timestamp(LocalDateTime.now())
-                .message(exception.getMessage())
-                .build();
-
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(apiError);
+    public ResponseEntity<?> handler(EntityBeingUsedException exception, WebRequest request) {
+        return handleExceptionInternal(
+                exception,
+                exception.getMessage(),
+                new HttpHeaders(),
+                HttpStatus.CONFLICT,
+                request
+        );
     }
 
     @ExceptionHandler(GenericBusinessException.class)
-    public ResponseEntity<ApiError> handler(GenericBusinessException exception) {
-        ApiError apiError = ApiError.builder()
-                .timestamp(LocalDateTime.now())
-                .message(exception.getMessage())
-                .build();
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
+    public ResponseEntity<?> handler(GenericBusinessException exception, WebRequest request) {
+        return handleExceptionInternal(
+                exception,
+                exception.getMessage(),
+                new HttpHeaders(),
+                HttpStatus.BAD_REQUEST,
+                request
+        );
     }
 
     /**
-     * Example of handling exceptions of Spring (not your own code), in order to provide your custom model for other exceptions.
+     * Customizes Spring's handleExceptionInternal to create a default body for all possible exceptions already
+     * handled by ResponseEntityExceptionHandler class that we extend here.
      *
-     * @param exception HttpMediaTypeNotSupportedException
-     * @return The ApiError with Unsupported Media Type (415) HTTP status code.
+     * @param ex      The exception, that won't be touched here..
+     * @param body    The HTTP response body, that will be defined here as being or ApiError class.
+     * @param headers The HTTP response headers, that won't be touched here.
+     * @param status  The HTTP status, that won't be touched here.
+     * @param request The HTTP request, that won't be touched here.
+     * @return call Spring's handleExceptionInternal.
      */
-    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<?> handler(HttpMediaTypeNotSupportedException exception) {
-        ApiError apiError = ApiError.builder()
-                .timestamp(LocalDateTime.now())
-                .message(exception.getMessage())
-                .build();
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
 
-        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(apiError);
+        if (body == null) {
+            body = ApiError.builder()
+                    .timestamp(LocalDateTime.now())
+                    .message(status.getReasonPhrase())
+                    .build();
+        } else if (body instanceof String) {
+            body = ApiError.builder()
+                    .timestamp(LocalDateTime.now())
+                    .message((String) body)
+                    .build();
+        }
+
+        return super.handleExceptionInternal(ex, body, headers, status, request);
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/CityNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/CityNotFoundException.java
@@ -1,0 +1,18 @@
+package dev.drugowick.algaworks.algafoodapi.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND)
+public class CityNotFoundException extends EntityNotFoundException {
+
+    private static final long serialVersionUID = 1L;
+
+    public CityNotFoundException(String message) {
+        super(message);
+    }
+
+    public CityNotFoundException(Long id) {
+        this(String.format("There's no City with the id %d.", id));
+    }
+}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/CuisineNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/CuisineNotFoundException.java
@@ -4,12 +4,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.NOT_FOUND)
-public abstract class EntityNotFoundException extends GenericBusinessException {
+public class CuisineNotFoundException extends EntityNotFoundException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityNotFoundException(String message) {
+	public CuisineNotFoundException(String message) {
 		super(message);
+	}
+
+	public CuisineNotFoundException(Long id) {
+		this(String.format("There's no Cuisine with the id %d.", id));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
@@ -1,5 +1,9 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
 public class EntityBeingUsedException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
@@ -1,11 +1,19 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
-public class EntityBeingUsedException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class EntityBeingUsedException extends ResponseStatusException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityBeingUsedException(String message) {
-		super(message);
+	public EntityBeingUsedException(HttpStatus status, String reason) {
+		super(status, reason);
 	}
+
+	public EntityBeingUsedException(String message) {
+		this(HttpStatus.CONFLICT, message);
+	}
+
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
@@ -1,9 +1,5 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(HttpStatus.CONFLICT)
 public class EntityBeingUsedException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityBeingUsedException.java
@@ -1,18 +1,15 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-public class EntityBeingUsedException extends ResponseStatusException {
+@ResponseStatus(code = HttpStatus.CONFLICT)
+public class EntityBeingUsedException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityBeingUsedException(HttpStatus status, String reason) {
-		super(status, reason);
-	}
-
 	public EntityBeingUsedException(String message) {
-		this(HttpStatus.CONFLICT, message);
+		super(message);
 	}
 
 

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
@@ -1,18 +1,15 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-public class EntityNotFoundException extends ResponseStatusException {
+@ResponseStatus(code = HttpStatus.NOT_FOUND)
+public class EntityNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityNotFoundException(HttpStatus status, String reason) {
-		super(status, reason);
-	}
-
 	public EntityNotFoundException(String message) {
-		this(HttpStatus.NOT_FOUND, message);
+		super(message);
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
@@ -1,9 +1,13 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class EntityNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	public EntityNotFoundException(String message) {
 		super(message);
 	}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
@@ -1,9 +1,5 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(HttpStatus.NOT_FOUND)
 public class EntityNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/EntityNotFoundException.java
@@ -1,11 +1,18 @@
 package dev.drugowick.algaworks.algafoodapi.domain.exception;
 
-public class EntityNotFoundException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class EntityNotFoundException extends ResponseStatusException {
 
 	private static final long serialVersionUID = 1L;
 
+	public EntityNotFoundException(HttpStatus status, String reason) {
+		super(status, reason);
+	}
+
 	public EntityNotFoundException(String message) {
-		super(message);
+		this(HttpStatus.NOT_FOUND, message);
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/GenericBusinessException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/GenericBusinessException.java
@@ -12,5 +12,8 @@ public class GenericBusinessException extends RuntimeException {
 		super(message);
 	}
 
+	public GenericBusinessException(String message, Throwable cause) {
+		super(message, cause);
+	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/GenericBusinessException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/GenericBusinessException.java
@@ -1,0 +1,16 @@
+package dev.drugowick.algaworks.algafoodapi.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST)
+public class GenericBusinessException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public GenericBusinessException(String message) {
+		super(message);
+	}
+
+
+}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/PaymentMethodNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/PaymentMethodNotFoundException.java
@@ -4,12 +4,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.NOT_FOUND)
-public abstract class EntityNotFoundException extends GenericBusinessException {
+public class PaymentMethodNotFoundException extends EntityNotFoundException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityNotFoundException(String message) {
+	public PaymentMethodNotFoundException(String message) {
 		super(message);
+	}
+
+	public PaymentMethodNotFoundException(Long id) {
+		this(String.format("There's no Payment Method with the id %d", id));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/PermissionNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/PermissionNotFoundException.java
@@ -4,12 +4,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.NOT_FOUND)
-public abstract class EntityNotFoundException extends GenericBusinessException {
+public class PermissionNotFoundException extends EntityNotFoundException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityNotFoundException(String message) {
+	public PermissionNotFoundException(String message) {
 		super(message);
+	}
+
+	public PermissionNotFoundException(Long id) {
+		this(String.format("There's no Permission with the id %d", id));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/ProvinceNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/ProvinceNotFoundException.java
@@ -4,12 +4,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.NOT_FOUND)
-public abstract class EntityNotFoundException extends GenericBusinessException {
+public class ProvinceNotFoundException extends EntityNotFoundException {
 
 	private static final long serialVersionUID = 1L;
 
-	public EntityNotFoundException(String message) {
+	public ProvinceNotFoundException(String message) {
 		super(message);
+	}
+
+	public ProvinceNotFoundException(Long id) {
+		this(String.format("There's no Province with the id %d", id));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/RestaurantNotFoundException.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/exception/RestaurantNotFoundException.java
@@ -1,0 +1,18 @@
+package dev.drugowick.algaworks.algafoodapi.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND)
+public class RestaurantNotFoundException extends EntityNotFoundException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RestaurantNotFoundException(String message) {
+        super(message);
+    }
+
+    public RestaurantNotFoundException(Long id) {
+        this(String.format("There's no Restaurant with the id %d.", id));
+    }
+}

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/CityCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/CityCrudService.java
@@ -1,5 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.domain.service;
 
+import dev.drugowick.algaworks.algafoodapi.domain.exception.CityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.City;
@@ -13,7 +14,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class CityCrudService {
 
-    public static final String MSG_NO_CITY = "There's no City with the id %d.";
     public static final String MSG_CITY_CONFLICT = "Operation on City %d conflicts with another entity and can not be performed.";
 
     private CityRepository cityRepository;
@@ -44,8 +44,7 @@ public class CityCrudService {
             throw new EntityBeingUsedException(
                     String.format(MSG_CITY_CONFLICT, id));
         } catch (EmptyResultDataAccessException e) {
-            throw new EntityNotFoundException(
-                    String.format(MSG_NO_CITY, id));
+            throw new CityNotFoundException(id);
         }
     }
 
@@ -57,8 +56,6 @@ public class CityCrudService {
      */
     public City findOrElseThrow(Long id) {
         return cityRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        String.format(MSG_NO_CITY, id)
-                ));
+                .orElseThrow(() -> new CityNotFoundException(id));
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/CuisineCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/CuisineCrudService.java
@@ -1,5 +1,6 @@
 package dev.drugowick.algaworks.algafoodapi.domain.service;
 
+import dev.drugowick.algaworks.algafoodapi.domain.exception.CuisineNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Cuisine;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class CuisineCrudService {
 
-	public static final String MSG_NO_CUISINE = "There's no Cuisine with the id %d.";
 	public static final String MSG_CUISINE_CONFLICT = "Operation on Cuisine %d conflicts with another entity and can not be performed.";
 
 	private CuisineRepository cuisineRepository;
@@ -41,8 +41,7 @@ public class CuisineCrudService {
 			throw new EntityBeingUsedException(
 					String.format(MSG_CUISINE_CONFLICT, id));
 		} catch (EmptyResultDataAccessException exception) {
-			throw new EntityNotFoundException(
-					String.format(MSG_NO_CUISINE, id));
+			throw new CuisineNotFoundException(id);
 		}
 	}
 
@@ -54,9 +53,7 @@ public class CuisineCrudService {
 	 */
 	public Cuisine findOrElseThrow(Long id) {
 		return cuisineRepository.findById(id)
-				.orElseThrow(() -> new EntityNotFoundException(
-						String.format(MSG_NO_CUISINE, id)
-				));
+				.orElseThrow(() -> new CuisineNotFoundException(id));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/CuisineCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/CuisineCrudService.java
@@ -10,32 +10,53 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CuisineCrudService {
-	
+
+	public static final String MSG_NO_CUISINE = "There's no Cuisine with the id %d.";
+	public static final String MSG_CUISINE_CONFLICT = "Operation on Cuisine %d conflicts with another entity and can not be performed.";
+
 	private CuisineRepository cuisineRepository;
 
 	public CuisineCrudService(CuisineRepository cuisineRepository) {
 		this.cuisineRepository = cuisineRepository;
 	}
-	
-	public Cuisine create(Cuisine cuisine) {
-		return cuisineRepository.save(cuisine);
+
+	public Cuisine save(Cuisine cuisine) {
+		try {
+			return cuisineRepository.save(cuisine);
+		} catch (DataIntegrityViolationException exception) {
+			throw new EntityBeingUsedException(
+					String.format(MSG_CUISINE_CONFLICT, cuisine.getId()));
+		}
 	}
-	
+
 	public Cuisine update(Long id, Cuisine cuisine) {
 		cuisine.setId(id);
 		return cuisineRepository.save(cuisine);
 	}
-	
+
 	public void delete(Long id) {
 		try {
 			cuisineRepository.deleteById(id);
 		} catch (DataIntegrityViolationException exception) {
 			throw new EntityBeingUsedException(
-					String.format("Cuisine %d is being used by another entity and can not be removed.", id));
+					String.format(MSG_CUISINE_CONFLICT, id));
 		} catch (EmptyResultDataAccessException exception) {
 			throw new EntityNotFoundException(
-					String.format("There's no Cuisine with the id %d.", id));
+					String.format(MSG_NO_CUISINE, id));
 		}
+	}
+
+	/**
+	 * Tries to find by ID and throws the business exception @{@link EntityNotFoundException} if not found.
+	 *
+	 * @param id of the entity to find.
+	 * @return the entity from the repository.
+	 */
+	public Cuisine findOrElseThrow(Long id) {
+		return cuisineRepository.findById(id)
+				.orElseThrow(() -> new EntityNotFoundException(
+						String.format(MSG_NO_CUISINE, id)
+				));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PaymentMethodCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PaymentMethodCrudService.java
@@ -2,6 +2,7 @@ package dev.drugowick.algaworks.algafoodapi.domain.service;
 
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.PaymentMethodNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.PaymentMethod;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.PaymentMethodRepository;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class PaymentMethodCrudService {
 
-    public static final String MSG_NO_PAYMENT_METHOD = "There's no Payment Method with the id %d.";
     public static final String MSG_PAYMENT_METHOD_CONFLICT = "Operation on Payment Method %d conflicts with another entity and can not be performed.";
 
     private PaymentMethodRepository paymentMethodRepository;
@@ -36,8 +36,7 @@ public class PaymentMethodCrudService {
             throw new EntityBeingUsedException(
                     String.format(MSG_PAYMENT_METHOD_CONFLICT, id));
         } catch (EmptyResultDataAccessException e) {
-            throw new EntityNotFoundException(
-                    String.format(MSG_NO_PAYMENT_METHOD, id));
+            throw new PaymentMethodNotFoundException(id);
         }
     }
 
@@ -49,8 +48,6 @@ public class PaymentMethodCrudService {
      */
     public PaymentMethod findOrElseThrow(Long id) {
         return paymentMethodRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        String.format(MSG_NO_PAYMENT_METHOD, id)
-                ));
+                .orElseThrow(() -> new PaymentMethodNotFoundException(id));
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PaymentMethodCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PaymentMethodCrudService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class PaymentMethodCrudService {
 
+    public static final String MSG_NO_PAYMENT_METHOD = "There's no Payment Method with the id %d.";
+    public static final String MSG_PAYMENT_METHOD_CONFLICT = "Operation on Payment Method %d conflicts with another entity and can not be performed.";
+
     private PaymentMethodRepository paymentMethodRepository;
 
     public PaymentMethodCrudService(PaymentMethodRepository paymentMethodRepository) {
@@ -18,7 +21,12 @@ public class PaymentMethodCrudService {
     }
 
     public PaymentMethod save(PaymentMethod paymentMethod) {
-        return paymentMethodRepository.save(paymentMethod);
+        try {
+            return paymentMethodRepository.save(paymentMethod);
+        } catch (DataIntegrityViolationException exception) {
+            throw new EntityBeingUsedException(
+                    String.format(MSG_PAYMENT_METHOD_CONFLICT, paymentMethod.getId()));
+        }
     }
 
     public void delete(Long id) {
@@ -26,10 +34,23 @@ public class PaymentMethodCrudService {
             paymentMethodRepository.deleteById(id);
         } catch (DataIntegrityViolationException e) {
             throw new EntityBeingUsedException(
-                    String.format("Payment Method %d is being used by another entity and can not be removed.", id));
+                    String.format(MSG_PAYMENT_METHOD_CONFLICT, id));
         } catch (EmptyResultDataAccessException e) {
             throw new EntityNotFoundException(
-                    String.format("There's no Payment Method with the id %d.", id));
+                    String.format(MSG_NO_PAYMENT_METHOD, id));
         }
+    }
+
+    /**
+     * Tries to find by ID and throws the business exception @{@link EntityNotFoundException} if not found.
+     *
+     * @param id of the entity to find.
+     * @return the entity from the repository.
+     */
+    public PaymentMethod findOrElseThrow(Long id) {
+        return paymentMethodRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format(MSG_NO_PAYMENT_METHOD, id)
+                ));
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PermissionCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PermissionCrudService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class PermissionCrudService {
 
+    public static final String MSG_NO_PERMISSION = "There's no Permission with the id %d.";
+    public static final String MSG_PERMISSION_CONFLICT = "Operation on Permission %d conflicts with another entity and can not be performed.";
+
     private PermissionRepository permissionRepository;
 
     public PermissionCrudService(PermissionRepository permissionRepository) {
@@ -18,7 +21,12 @@ public class PermissionCrudService {
     }
 
     public Permission save(Permission permission) {
-        return permissionRepository.save(permission);
+        try {
+            return permissionRepository.save(permission);
+        } catch (DataIntegrityViolationException exception) {
+            throw new EntityBeingUsedException(
+                    String.format(MSG_PERMISSION_CONFLICT, permission.getId()));
+        }
     }
 
     public void delete(Long id) {
@@ -26,10 +34,23 @@ public class PermissionCrudService {
             permissionRepository.deleteById(id);
         } catch (DataIntegrityViolationException e) {
             throw new EntityBeingUsedException(
-                    String.format("Permission %d is being used by another entity and can not be removed.", id));
+                    String.format(MSG_PERMISSION_CONFLICT, id));
         } catch (EmptyResultDataAccessException e) {
             throw new EntityNotFoundException(
-                    String.format("There's no Permission with the id %d.", id));
+                    String.format(MSG_NO_PERMISSION, id));
         }
+    }
+
+    /**
+     * Tries to find by ID and throws the business exception @{@link EntityNotFoundException} if not found.
+     *
+     * @param id of the entity to find.
+     * @return the entity from the repository.
+     */
+    public Permission findOrElseThrow(Long id) {
+        return permissionRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format(MSG_NO_PERMISSION, id)
+                ));
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PermissionCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/PermissionCrudService.java
@@ -2,6 +2,7 @@ package dev.drugowick.algaworks.algafoodapi.domain.service;
 
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.PermissionNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Permission;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.PermissionRepository;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class PermissionCrudService {
 
-    public static final String MSG_NO_PERMISSION = "There's no Permission with the id %d.";
     public static final String MSG_PERMISSION_CONFLICT = "Operation on Permission %d conflicts with another entity and can not be performed.";
 
     private PermissionRepository permissionRepository;
@@ -36,8 +36,7 @@ public class PermissionCrudService {
             throw new EntityBeingUsedException(
                     String.format(MSG_PERMISSION_CONFLICT, id));
         } catch (EmptyResultDataAccessException e) {
-            throw new EntityNotFoundException(
-                    String.format(MSG_NO_PERMISSION, id));
+            throw new PermissionNotFoundException(id);
         }
     }
 
@@ -49,8 +48,6 @@ public class PermissionCrudService {
      */
     public Permission findOrElseThrow(Long id) {
         return permissionRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        String.format(MSG_NO_PERMISSION, id)
-                ));
+                .orElseThrow(() -> new PermissionNotFoundException(id));
     }
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/ProvinceCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/ProvinceCrudService.java
@@ -2,6 +2,7 @@ package dev.drugowick.algaworks.algafoodapi.domain.service;
 
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.ProvinceNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Province;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.ProvinceRepository;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class ProvinceCrudService {
 
-	public static final String MSG_NO_PROVINCE = "There's no Province with the id %d.";
 	public static final String MSG_PROVINCE_CONFLICT = "Operation on Province %d conflicts with another entity and can not be performed.";
 
 	private ProvinceRepository provinceRepository;
@@ -36,8 +36,7 @@ public class ProvinceCrudService {
 			throw new EntityBeingUsedException(
 					String.format(MSG_PROVINCE_CONFLICT, id));
 		} catch (EmptyResultDataAccessException e) {
-			throw new EntityNotFoundException(
-					String.format(MSG_NO_PROVINCE, id));
+			throw new ProvinceNotFoundException(id);
 		}
 	}
 
@@ -49,9 +48,7 @@ public class ProvinceCrudService {
 	 */
 	public Province findOrElseThrow(Long id) {
 		return provinceRepository.findById(id)
-				.orElseThrow(() -> new EntityNotFoundException(
-						String.format(MSG_NO_PROVINCE, id)
-				));
+				.orElseThrow(() -> new ProvinceNotFoundException(id));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/ProvinceCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/ProvinceCrudService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ProvinceCrudService {
 
+	public static final String MSG_NO_PROVINCE = "There's no Province with the id %d.";
+	public static final String MSG_PROVINCE_CONFLICT = "Operation on Province %d conflicts with another entity and can not be performed.";
+
 	private ProvinceRepository provinceRepository;
 
 	public ProvinceCrudService(ProvinceRepository provinceRepository) {
@@ -18,7 +21,12 @@ public class ProvinceCrudService {
 	}
 
 	public Province save(Province province) {
-		return provinceRepository.save(province);
+		try {
+			return provinceRepository.save(province);
+		} catch (DataIntegrityViolationException exception) {
+			throw new EntityBeingUsedException(
+					String.format(MSG_PROVINCE_CONFLICT, province.getId()));
+		}
 	}
 
 	public void delete(Long id) {
@@ -26,11 +34,24 @@ public class ProvinceCrudService {
 			provinceRepository.deleteById(id);
 		} catch (DataIntegrityViolationException e) {
 			throw new EntityBeingUsedException(
-					String.format("Province %d is being used by another entity and can not be removed.", id));
+					String.format(MSG_PROVINCE_CONFLICT, id));
 		} catch (EmptyResultDataAccessException e) {
 			throw new EntityNotFoundException(
-					String.format("There's no Province with the id %d.", id));
+					String.format(MSG_NO_PROVINCE, id));
 		}
+	}
+
+	/**
+	 * Tries to find by ID and throws the business exception @{@link EntityNotFoundException} if not found.
+	 *
+	 * @param id of the entity to find.
+	 * @return the entity from the repository.
+	 */
+	public Province findOrElseThrow(Long id) {
+		return provinceRepository.findById(id)
+				.orElseThrow(() -> new EntityNotFoundException(
+						String.format(MSG_NO_PROVINCE, id)
+				));
 	}
 
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/RestaurantCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/RestaurantCrudService.java
@@ -2,6 +2,7 @@ package dev.drugowick.algaworks.algafoodapi.domain.service;
 
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityBeingUsedException;
 import dev.drugowick.algaworks.algafoodapi.domain.exception.EntityNotFoundException;
+import dev.drugowick.algaworks.algafoodapi.domain.exception.RestaurantNotFoundException;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Cuisine;
 import dev.drugowick.algaworks.algafoodapi.domain.model.Restaurant;
 import dev.drugowick.algaworks.algafoodapi.domain.repository.CuisineRepository;
@@ -13,7 +14,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class RestaurantCrudService {
 
-	public static final String MSG_NO_RESTAURANT = "There's no Restaurant with the id %d.";
 	public static final String MSG_RESTAURANT_CONFLICT = "Operation on Restaurant %d conflicts with another entity and can not be performed.";
 
 	private RestaurantRepository restaurantRepository;
@@ -44,8 +44,7 @@ public class RestaurantCrudService {
 			throw new EntityBeingUsedException(
 					String.format(MSG_RESTAURANT_CONFLICT, id));
 		} catch (EmptyResultDataAccessException exception) {
-			throw new EntityNotFoundException(
-					String.format(MSG_NO_RESTAURANT, id));
+			throw new RestaurantNotFoundException(id);
 		}
 	}
 
@@ -57,8 +56,6 @@ public class RestaurantCrudService {
 	 */
 	public Restaurant findOrElseThrow(Long id) {
 		return restaurantRepository.findById(id)
-				.orElseThrow(() -> new EntityNotFoundException(
-						String.format(MSG_NO_RESTAURANT, id)
-				));
+				.orElseThrow(() -> new RestaurantNotFoundException(id));
 	}
 }

--- a/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/RestaurantCrudService.java
+++ b/src/main/java/dev/drugowick/algaworks/algafoodapi/domain/service/RestaurantCrudService.java
@@ -15,6 +15,9 @@ import java.util.Optional;
 @Service
 public class RestaurantCrudService {
 
+	public static final String MSG_NO_RESTAURANT = "There's no Restaurant with the id %d.";
+	public static final String MSG_RESTAURANT_IN_USE = "Restaurant %d is being used by another entity and can not be removed.";
+
 	private RestaurantRepository restaurantRepository;
 	private CuisineRepository cuisineRepository;
 
@@ -41,10 +44,23 @@ public class RestaurantCrudService {
 			restaurantRepository.deleteById(id);
 		} catch (DataIntegrityViolationException exception) {
 			throw new EntityBeingUsedException(
-					String.format("Restaurant %d is being used by another entity and can not be removed.", id));
+					String.format(MSG_RESTAURANT_IN_USE, id));
 		} catch (EmptyResultDataAccessException exception) {
 			throw new EntityNotFoundException(
-					String.format("There's no Restaurant with the id %d.", id));
+					String.format(MSG_NO_RESTAURANT, id));
 		}
+	}
+
+	/**
+	 * Tries to find by ID and throws the business exception @{@link EntityNotFoundException} if not found.
+	 *
+	 * @param id of the Restaurant to find.
+	 * @return the Restaurant from the repository.
+	 */
+	public Restaurant findOrElseThrow(Long id) {
+		return restaurantRepository.findById(id)
+				.orElseThrow(() -> new EntityNotFoundException(
+						String.format(MSG_NO_RESTAURANT, id)
+				));
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,8 @@ spring.flyway.locations=classpath:db/migration,classpath:db/testdata
 ## Below are properties used only to generate the DDL using the JPA entity definitions. It'll be kept for reference.
 #spring.jpa.properties.javax.persistence.schema-generation.scripts.action=create
 #spring.jpa.properties.javax.persistence.schema-generation.scripts.create-target=src/main/resources/ddl.sql
+## Jackson properties
+# fail-on-unknown-properties determines if json values not mapped to java object properties cause failure of the request.
+spring.jackson.deserialization.fail-on-unknown-properties=true
+# fail-on-ignored-properties determines if json values configured to be ignored with @JsonIgnore cause failure of the request.
+spring.jackson.deserialization.fail-on-ignored-properties=true


### PR DESCRIPTION
# Evolution of Exception Handling

## Introduces @ResponseStatus class annotation. 6fff831

Up to this point we have been using this annotation on methods. Now we introduced this on a class, which happens to be an exception, so when it's thrown (not handled) the HTTP response code is defined by this annotation on the class. So exceptions are not handled on the controller anymore (for the example here, which is deletion of Restaurants).
This introduces something BAD: we're dealing with HTTP stuff on the service layer. That's no good, that's bad! Bad developer, bad! (p.s.: well, o

`Note: Well, that's not soooo bad. It only adds HTTP-related stfuff to exception classes, which will use the HTTP stuff only if the exception is passed as a HTTP response.`

## Introduces Spring's ResponseStatusException class. 7443992

ResponseStatusException class allows you throw an exception with a specific message and HTTP status code. A good fit for simple PoCs.
With that, it's not necessary to handle HTTP codes on the service exception classes (ee how the exception classes are back to being basic), but you still are kind of limited.
Let's follow along...

## Makes business exceptions extend ResponseStatusException. 7969a5dc036fcd74819348997cb5e8c53ad496ac

In this approach, our exceptions extend ResponseStatusExceptions, which makes the Controller code much simpler, since it doesn't have to catch business exceptions and throw a new web exception. Also, each exception is overloaded with a constructor that adds the ability to customize the HTTP status code for the exception. It sounds awkward to e able to customize the HTTP status code in this project... because it is! We are not going to use it here. This would, though, be extremely useful if you want to create a unique and generic exception class to return multiple HTTP status codes. When throwing you would add the corresponding HTTP status code for different business rules (conflict, not found etc.).

Ok, you notice that there's no way to fully segregate business and web layer. Yeah, I know. We are going to deal with this later.    

## Returns to @ResponseStatus class annotation. fd39cb2ca14a5fd7fecd9191c4ff5ab92e4749ea

Since we want specific business layer exceptions, we are returning to the solution where the business exception is annotated with the HTTP status code related to what the exception means. This couples api/http and business layers just a tiny little bit (the actual @ResponseStatus class annotation on the exceptions).
But combining this with a method on the service layer that, in this case, finds an entity or else throws the corresponding business exception, we were able to make the controller code much more readable and simple.

## Adds a GenericBusinessException to normalize API exception format. b65e49252a63bb3da5a39d96a74517e55c4a8efb

City and Restaurant, which have related entities, were catching the problem of the related entity not existing and returning a custom ResponseEntity with an error. The problem is that this return is different from the business exceptions at this point, that were already using a format like so:

```json
{
  "timestamp": "2020-01-18T12:32:40.857+0000",
  "status": 404,
  "error": "Not Found",
  "message": "There's no Restaurant with the id 50.",
  "trace": "<omitted for brevity>",
  "path": "/restaurants/50"
}
```
By adding a GenericBusinessException, we can now control on the Controller the type of Exception to return according to the desired HTTP status code required. It's ok to have this logic on the controller: http-related stuff should be dealt with on the controller!

## Adds better exception granularity. 0c1c6e649f9d11942b02f9e1541cafaf7fe0ef03

Creates new custom ProvinceNotFound exception extending EntityNotFoundException. This is useful in cases where granular tratment/catch is necessary but you don't need to create exceptions for each and every entity. One must use its brain to decide which entities will have custom exceptions.

These new exceptions include a constructor that gets the entity ID and already formats the message, removing the need to format the messages on the caller classes when the exception is so specific already.

Throws that specific exceptions when dealing with something that throws them (in the Restaurant and City controllers, throwing Cuisine and Province exceptions, respectively).

Adds an option to throw GenericBusinessException with a cause (another exception that literally caused the generic one). Throws with cause on the controllers now.

Makes EntityNotFoundException extends GenericBusinessException, creating a more concise hierarchy.

Replicates this logic for City, Cuisine, Permission, PaymentMethod and Restaurant and then makes EntityNotFoundException abstract. This makes it still possible to catch this generic EntityNotFoundException (like we do in the controllers, in case there's more than one dependant entity), but we can not instantiate and throw, because we should throw the specific exceptions. This makes necessary to have specific exceptions for each entity. That's a decision. That's ok if you believe that's the case.

## Adds ExceptionHandler annotation. 8f93fd86d65af56658344d50e4d6a5081de6d654

For demonstration purposes, adds an ApiError class and handler methods on the CityController. Demonstrates the use of @ExceptionHandler on the controllers and the return of a custom representation as error for the API.

## Adds a Controller Advice to handle exceptions from all controllers. b46ca1f31bed270846001d50008b3c8335b962ec

Adds a method to handle an exception from Spring Framework, not from our code. This may be useful sometimes.
Obviously removes the specific handlers from the CityController, since this will be handled by the class with the @ControllerAdvice annotation.

## Adds extension to the convenience class ResponseEntityExceptionHandler on the Controller Advice. 297bef6531b3bae3632b2947d582aa9ea732bb6a

With this, it's possible to remove handlers for specific exceptions from outside our code and only customize the handleExceptionInternal method.

Also, the custom handlers can also use our implementation of handleExceptionInternal, providing a centralized way of defining response body for exceptions of the API.

## Complies with RFC 7807 - Problem Details for HTTP APIs. bdb994381e62a15d2da634ca41318200f0dfe9ae

RFC spec: https://tools.ietf.org/html/rfc7807. Defines the following fields to return in case of API problems/errors: status, type, title, detail. Also supports custom fields, which is the case of timestamp.

Defines an enum to help determining the title and type properties of the ApiError class.

Changes the ControllerAdvice code accordingly. Code is more readable and extendable now. The `ApiExceptionHandler.createApiErrorBuilder` helps building default values for ApiError and still customize fields like `timestamp`.

### Adds a method to handle exceptions on input Json. c3fadff2d7bce6d02f1d823848fce6a87db0cf50

These methods return a acceptale ApiError on erros with Json input from the client while also tries to hint the client on what should be verified.
I took the opportunity to move the timestamp field to the createApiErrorBuilder method.

---

#### At this point this architecture of the code is pretty much defined.

---

## Adds Jackson properties to fail on specific conditions... 31740045515a0e38e681b518b6981624aa2d3a63

... based on the input Json.
The property fail-on-unknown-properties determines if json values not mapped to java object properties cause failure of the request.
The property fail-on-ignored-properties determines if json values configured to be ignored with @JsonIgnore cause failure of the request.

## Adds a default exception handler. 8f39789fe7c34141807c2c584128ad30b3b3e430

This is a generic method to handle any other exception. Maybe this should be the first method to be created in other opportunities, and custom handlers are developed later.

## Customizes the error representation with a userMessage. 4dcc5fd8317cf59511a824814fec929d884880b7

This allows the clients of the API to forward by default the error message to the user.
